### PR TITLE
Partial symri outputs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,10 +7,11 @@ Welcome to HBCD_SYMRI_POSTPROC's documentation!
 ===============================================
 
 This tool is used in the Healthy Brain and Child Development (HBCD) study
-following the conversion of QALAS acquisitions to T1, T2, and PD maps.
+to run minimal post-processing on synthetic images generated from `SyMRI <https://syntheticmr.com/products/symri-neuro/>`_
+tools using the `QALAS acquisition <https://pubmed.ncbi.nlm.nih.gov/25526880/>`_.
 The purpose of the tool is to take quantitative maps, register them to
 either raw T1w or T2w images where anatomical segmentations have already
-been performed, and then extract quantitative values from the segmentations.
+been performed, and then extract quantitative values within regions of interest.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/inputs_formatting.rst
+++ b/docs/source/inputs_formatting.rst
@@ -14,7 +14,7 @@ for each session that will be processed. The T1w and/or T2w image
 should already be registered to the segmentation(s) found in the
 segmentations directory. If both T1w/T2w images and segmentations
 are present, the pipeline will currently (as of 6/5/24) give priority
-to registering the relaxometry images to the T2w images.
+to registering the relaxometry images to the T2w images by default.
 
 SyMRI/relaxometry directory
 ---------------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,8 +6,8 @@
 Installation
 ============
 
-The intended use of this pipeline is through the use of a Singularity/Docker
-image. The image can be built using the Dockerfile found in the repository,
+The intended use of this pipeline is through the use of a `Singularity <https://docs.sylabs.io/guides/3.7/user-guide/index.html>`_  or `Docker <https://docs.docker.com/get-started/>`_
+image. The image can be built using the Dockerfile found in the `repository <https://github.com/erikglee/HBCD_SYMRI_POSTPROC>`_,
 or it can be pulled from DockerHub as a singularity using the following command: ::
     
         singularity pull docker://dcanumn/hbcd_symri_postproc:<version_num>

--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -12,9 +12,7 @@ the primary output folder of interest will be as follows: ::
 
     <output_dir>/sub-{label}/ses-{label}/anat/
 
-During processing, the application will generate synthetic T1w/T2w
-images under the "qalas_derived_weighted_images" folder. These images
-are created to have the following parameters: ::
+The application expects synthetic T1w/T2w images to be... ::
 
     T1: TR = XXms, TE = XXms
     T2: TR = XXms, TE = XXms

--- a/postproc_code/my_parser.py
+++ b/postproc_code/my_parser.py
@@ -17,5 +17,6 @@ def build_parser():
     parser.add_argument('--overwrite_existing', help='OPTIONAL: if flag is activated, the tool will delete the session folder where outputs are to be stored before processing if said folder already exists.', action='store_true')
     parser.add_argument('--skip_existing', help='OPTIONAL: if flag is activated, the tool will skip processing for a session if the session folder where outputs are to be stored already exists.', action='store_true')
     parser.add_argument('--region_groupings_json', nargs='+', help='OPTIONAL: the path to a json file containing region groupings for which to calculate statistics. Multiple files can be provided, resulting in multiple output csv files.', type=str)
+    parser.add_argument('--sequence_name_source', help='OPTIONAL: the the key for the key/value pair to try and grab sequence name from. For example if the qMRI file is named sub-1_acq-QALAS.nii.gz, this should be "acq". If the sequence is found, it will be represented as "quant" in the output files.', type=str, default = 'acq')
 
     return parser

--- a/postproc_code/my_parser.py
+++ b/postproc_code/my_parser.py
@@ -8,7 +8,7 @@ def build_parser():
     parser.add_argument("bids_dir", help="The path to the BIDS directory for your study (this is the same for all subjects)", type=str)
     parser.add_argument("output_dir", help="The path to the folder where outputs will be stored (this is the same for all subjects)", type=str)
     parser.add_argument("analysis_level", help="Should always be participant", type=str)
-    parser.add_argument("symri_deriv_dir", help="The path to the folder where the SyMRI Relaxometry Maps are stored (this is the same for all subjects)", type=str)
+    parser.add_argument("qmri_deriv_dir", help="The path to the folder where the SyMRI Relaxometry Maps are stored (this is the same for all subjects)", type=str)
     parser.add_argument("bibsnet_deriv_dir", help="The path to the folder where the BIBSNET/CABINET segmentations are stored (this is the same for all subjects)", type=str)
 
 

--- a/postproc_code/my_parser.py
+++ b/postproc_code/my_parser.py
@@ -8,7 +8,7 @@ def build_parser():
     parser.add_argument("bids_dir", help="The path to the BIDS directory for your study (this is the same for all subjects)", type=str)
     parser.add_argument("output_dir", help="The path to the folder where outputs will be stored (this is the same for all subjects)", type=str)
     parser.add_argument("analysis_level", help="Should always be participant", type=str)
-    parser.add_argument("qmri_deriv_dir", help="The path to the folder where the SyMRI Relaxometry Maps are stored (this is the same for all subjects)", type=str)
+    parser.add_argument("qmri_deriv_dir", help="The path to the folder where the qMRI Relaxometry Maps are stored (this is the same for all subjects)", type=str)
     parser.add_argument("bibsnet_deriv_dir", help="The path to the folder where the BIBSNET/CABINET segmentations are stored (this is the same for all subjects)", type=str)
 
 

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -368,7 +368,7 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     for temp_symri_map in symri_map_path_dict.keys():
         temp_map = ants.image_read(symri_map_path_dict[temp_symri_map])
         temp_map_transformed = ants.apply_transforms(anatomical_reference, temp_map, reg['fwdtransforms'], interpolator = Map_Interpolation_Scheme)
-        maps_array_dict[temp_symri_map] = np.array(temp_map_transformed[:])
+        maps_array_dict[temp_symri_map] = np.array(temp_map[:])
         registered_temp_map_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.nii'.format(subject_name, session_name, anatomical_reference_modality, temp_symri_map))
         registered_maps_paths[temp_symri_map] = registered_temp_map_path
         print('      Saving {}'.format(registered_temp_map_path))

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -376,6 +376,8 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         registered_temp_map_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.nii'.format(subject_name, session_name, anatomical_reference_modality, temp_symri_map))
         registered_maps_paths[temp_symri_map] = registered_temp_map_path
         print('      Saving {}'.format(registered_temp_map_path))
+        if os.path.exists(anat_out_dir) == False:
+            os.makedirs(anat_out_dir)
         ants.image_write(temp_map_transformed, registered_temp_map_path)
     #Also transform the segmentation image back to QALAS (i.e. T1map/T2map/PDmap) space
     Segmentation_Interpolation_Scheme = 'nearestNeighbor'

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -257,7 +257,7 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         anatomical_reference_modality = 'T2w'
         bibsnet_seg_path = t2w_segs[0]
         bibsnet_mask_path = bibsnet_seg_path.replace('desc-aseg_dseg.nii.gz', 'desc-brain_mask.nii.gz')
-        if os.path.exists(bibsnet_mask) == False:
+        if os.path.exists(bibsnet_mask_path) == False:
             raise ValueError('Error: A T2w BIBSNET segmentation was found without a corresponding mask. Expected to find mask with name: {}'.format(bibsnet_mask_path))
         possible_anatomical_references = glob.glob(os.path.join(bids_directory, subject_name, session_name, 'anat', '*T2w.nii.gz'))
         if len(possible_anatomical_references) != 1:

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -375,6 +375,8 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         if os.path.exists(anat_out_dir) == False:
             os.makedirs(anat_out_dir)
         ants.image_write(temp_map_transformed, registered_temp_map_path)
+        replace_file_with_gzipped_version(registered_temp_map_path)
+        registered_maps_paths[temp_symri_map] = registered_temp_map_path + '.gz'
     #Also transform the segmentation image back to QALAS (i.e. T1map/T2map/PDmap) space
     Segmentation_Interpolation_Scheme = 'nearestNeighbor'
     segmentation_reverse_transformed = ants.apply_transforms(symri_for_reg, segmentation, reg['fwdtransforms'], interpolator = Segmentation_Interpolation_Scheme, whichtoinvert = [True])

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -358,10 +358,10 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     adjusted_bibsnet_mask = remove_extra_clusters_from_mask(bibsnet_mask)
     dilated_mask = ants.utils.morphology(adjusted_bibsnet_mask, 'dilate', 35)
     if anatomical_reference_modality == 'T1w':
-        symri_for_reg = ants.image_read(symri_t1w_path)
+        symri_for_reg = ants.image_read(symri_t1w_path[0])
         reg = ants.registration(anatomical_reference, symri_for_reg, type_of_transform='Rigid', initial_transform=None, mask=dilated_mask)
     elif anatomical_reference_modality == 'T2w':
-        symri_for_reg = ants.image_read(symri_t2w_path)
+        symri_for_reg = ants.image_read(symri_t2w_path[0])
         reg = ants.registration(anatomical_reference, symri_for_reg, type_of_transform='Rigid', initial_transform=None, mask=dilated_mask)
 
     #Apply the transform calculated above to the t1map, t2map, and pdmap images

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -397,22 +397,11 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     color_lut_df = load_color_lut_df()
     
     #Initialize a dictionary to store all the ROI values/names
-    roi_params_dict = {'Region_Name' : [],
-                       'T1_Mean': [],
-                       'T2_Mean': [],
-                       'PD_Mean': [],
-                       'T1_Median': [],
-                       'T2_Median': [],
-                       'PD_Median': [],
-                       'T1_1-percentile' : [],
-                       'T2_1-percentile' : [],
-                       'PD_1-percentile' : [],
-                       'T1_99-percentile' : [],
-                       'T2_99-percentile' : [],
-                       'PD_99-percentile' : [],
-                       'T1_Std' : [],
-                       'T2_Std' : [],
-                       'PD_Std' : []}
+    measure_tpyes = ['Mean', 'Median', '1-percentile', '99-percentile', 'Std']
+    roi_params_dict = {'Region_Name' : []}
+    for temp_image_type in maps_array_dict.keys():
+        for temp_measure in measure_tpyes:
+            roi_params_dict[temp_image_type + '_' + temp_measure] = []
     
     #Find unique segmentation values########################################################
     ########################################################################################
@@ -473,22 +462,10 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     if type(custom_roi_groupings) != type(None):
         for temp_grouping_path in custom_roi_groupings:
             print('   Calculating Custom ROI Relaxometry Values for {}'.format(temp_grouping_path))
-            custom_roi_params_dict = {'Region_Name' : [],
-                    'T1_Mean': [],
-                    'T2_Mean': [],
-                    'PD_Mean': [],
-                    'T1_Median': [],
-                    'T2_Median': [],
-                    'PD_Median': [],
-                    'T1_1-percentile' : [],
-                    'T2_1-percentile' : [],
-                    'PD_1-percentile' : [],
-                    'T1_99-percentile' : [],
-                    'T2_99-percentile' : [],
-                    'PD_99-percentile' : [],
-                    'T1_Std' : [],
-                    'T2_Std' : [],
-                    'PD_Std' : []}
+            custom_roi_params_dict = {'Region_Name' : []}
+            for temp_image_type in maps_array_dict.keys():
+                for temp_measure in measure_tpyes:
+                    custom_roi_params_dict[temp_image_type + '_' + temp_measure] = []
 
 
             with open(temp_grouping_path, 'r') as f:

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -256,11 +256,9 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         print('   Using segmentation in T2w space as reference image')
         anatomical_reference_modality = 'T2w'
         bibsnet_seg_path = t2w_segs[0]
-        bibsnet_masks = glob.glob(os.path.join(bibsnet_directory, subject_name, session_name, 'anat', '*space-T2w_desc-brain_mask.nii.gz'))
-        if len(bibsnet_masks) == 0:
-            raise ValueError('Error: A T2w BIBSNET segmentation was found without a corresponding mask.')
-        else:
-            bibsnet_mask_path = bibsnet_masks[0]
+        bibsnet_mask_path = bibsnet_seg_path.replace('desc-aseg_dseg.nii.gz', 'desc-brain_mask.nii.gz')
+        if os.path.exists(bibsnet_mask) == False:
+            raise ValueError('Error: A T2w BIBSNET segmentation was found without a corresponding mask. Expected to find mask with name: {}'.format(bibsnet_mask_path))
         possible_anatomical_references = glob.glob(os.path.join(bids_directory, subject_name, session_name, 'anat', '*T2w.nii.gz'))
         if len(possible_anatomical_references) != 1:
             raise ValueError('Error: If a T2w segmentation is to be used for processing, only 1 T2w reference found in the subjects anat directory must be present but {} were found'.format(len(possible_anatomical_references)))
@@ -271,11 +269,9 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         print('   Using segmentation in T1w space as reference image')
         anatomical_reference_modality = 'T1w'
         bibsnet_seg_path = t1w_segs[0]
-        bibsnet_masks = glob.glob(os.path.join(bibsnet_directory, subject_name, session_name, 'anat', '*space-T1w_desc-brain_mask.nii.gz'))
-        if len(bibsnet_masks) == 0:
-            raise ValueError('Error: A T1w BIBSNET segmentation was found without a corresponding mask.')
-        else:
-            bibsnet_mask_path = bibsnet_masks[0]
+        bibsnet_mask_path = bibsnet_seg_path.replace('desc-aseg_dseg.nii.gz', 'desc-brain_mask.nii.gz')
+        if os.path.exists(bibsnet_mask_path) == False:
+            raise ValueError('Error: A T1w BIBSNET segmentation was found without a corresponding mask. Expected to find mask with name: {}'.format(bibsnet_mask_path))
         possible_anatomical_references = glob.glob(os.path.join(bids_directory, subject_name, session_name, 'anat', '*T1w.nii.gz'))
         if len(possible_anatomical_references) != 1:
             raise ValueError('Error: If a T1w segmentation is to be used for processing, only 1 T1w reference found in the subjects anat directory must be present but {} were found'.format(len(possible_anatomical_references)))

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -309,7 +309,7 @@ def calc_qmri_stats(bids_directory, bibsnet_directory,
     sequence_name = ''
     for temp_keyvalue in example_img_name.split('/')[-1].split('_'):
         if sequence_name_source == temp_keyvalue.split('-')[0]:
-            sequence_name = temp_keyvalue
+            sequence_name = temp_keyvalue.split('-')[1]
             break
     if sequence_name == '':
         sequence_name = 'quant'
@@ -381,18 +381,18 @@ def calc_qmri_stats(bids_directory, bibsnet_directory,
         temp_map = ants.image_read(qmri_map_path_dict[temp_qmri_map])
         temp_map_transformed = ants.apply_transforms(anatomical_reference, temp_map, reg['fwdtransforms'], interpolator = Map_Interpolation_Scheme)
         maps_array_dict[temp_qmri_map] = np.array(temp_map[:])
-        registered_temp_map_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.nii'.format(subject_name, session_name, anatomical_reference_modality, temp_qmri_map))
+        registered_temp_map_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-{}_{}map.nii'.format(subject_name, session_name, anatomical_reference_modality, sequence_name, temp_qmri_map))
         print('      Saving {}'.format(registered_temp_map_path))
         if os.path.exists(anat_out_dir) == False:
             os.makedirs(anat_out_dir)
         ants.image_write(temp_map_transformed, registered_temp_map_path)
         replace_file_with_gzipped_version(registered_temp_map_path)
         registered_maps_paths[temp_qmri_map] = registered_temp_map_path + '.gz'
-    #Also transform the segmentation image back to QALAS (i.e. T1map/T2map/PDmap) space
+    #Also transform the segmentation image back to qMRI (i.e. T1map/T2map/PDmap) space
     Segmentation_Interpolation_Scheme = 'nearestNeighbor'
     segmentation_reverse_transformed = ants.apply_transforms(qmri_for_reg, segmentation, reg['fwdtransforms'], interpolator = Segmentation_Interpolation_Scheme, whichtoinvert = [True])
     bibnset_file = bibsnet_seg_path.split('/')[-1]
-    registered_segmentation_path = os.path.join(anat_out_dir, bibnset_file.replace(bibnset_file.split('_')[-3], 'space-QALAS')).replace('.gz', '')
+    registered_segmentation_path = os.path.join(anat_out_dir, bibnset_file.replace(bibnset_file.split('_')[-3], 'space-{}'.format(sequence_name))).replace('.gz', '')
     ants.image_write(segmentation_reverse_transformed, registered_segmentation_path)
     registered_segmentation_path = replace_file_with_gzipped_version(registered_segmentation_path)
 
@@ -553,7 +553,7 @@ def calc_qmri_stats(bids_directory, bibsnet_directory,
     resampled_images_metadata['Original_qMRI_JSON_Metadata'] = qmri_json_dict
     resampled_images_metadata_json = json.dumps(resampled_images_metadata, indent = 5)
     for temp_qmri_map in qmri_map_path_dict.keys():
-        output_json_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.json'.format(subject_name, session_name, anatomical_reference_modality, temp_qmri_map))
+        output_json_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-{}_{}map.json'.format(subject_name, session_name, anatomical_reference_modality, sequence_name, temp_qmri_map))
         with open(output_json_path, 'w') as f:
             f.write(resampled_images_metadata_json) 
     

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -301,10 +301,10 @@ def calc_qmri_stats(bids_directory, bibsnet_directory,
             example_img_name = qmri_t1[0]
         if len(qmri_t2):
             qmri_map_path_dict['T2'] = qmri_t2[0]
-            example_img_name = qmri_t1[0]
+            example_img_name = qmri_t2[0]
         if len(qmri_pd):
             qmri_map_path_dict['PD'] = qmri_pd[0]
-            example_img_name = qmri_t1[0]
+            example_img_name = qmri_pd[0]
 
     sequence_name = ''
     for temp_keyvalue in example_img_name.split('/')[-1].split('_'):

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -375,6 +375,7 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         maps_array_dict[temp_symri_map] = np.array(temp_map_transformed[:])
         registered_temp_map_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.nii'.format(subject_name, session_name, anatomical_reference_modality, temp_symri_map))
         registered_maps_paths[temp_symri_map] = registered_temp_map_path
+        print('      Saving {}'.format(registered_temp_map_path))
         ants.image_write(temp_map_transformed, registered_temp_map_path)
     #Also transform the segmentation image back to QALAS (i.e. T1map/T2map/PDmap) space
     Segmentation_Interpolation_Scheme = 'nearestNeighbor'

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -213,7 +213,8 @@ def make_outline_overlay_underlay_plot_ribbon(path_to_underlay, path_to_overlay,
 
 def calc_qmri_stats(bids_directory, bibsnet_directory,
                      qmri_directory, output_directory,
-                     subject_name, session_name, custom_roi_groupings = None):
+                     subject_name, session_name, custom_roi_groupings = None,
+                     sequence_name_source = 'acq'):
     '''Function to generate items of interest based on quantitative MRI maps
     
     
@@ -297,10 +298,21 @@ def calc_qmri_stats(bids_directory, bibsnet_directory,
         qmri_map_path_dict = {}
         if len(qmri_t1):
             qmri_map_path_dict['T1'] = qmri_t1[0]
+            example_img_name = qmri_t1[0]
         if len(qmri_t2):
             qmri_map_path_dict['T2'] = qmri_t2[0]
+            example_img_name = qmri_t1[0]
         if len(qmri_pd):
             qmri_map_path_dict['PD'] = qmri_pd[0]
+            example_img_name = qmri_t1[0]
+
+    sequence_name = ''
+    for temp_keyvalue in example_img_name.split('/')[-1].split('_'):
+        if sequence_name_source == temp_keyvalue.split('-')[0]:
+            sequence_name = temp_keyvalue
+            break
+    if sequence_name == '':
+        sequence_name = 'quant'
         
     #########################################################################################################
     #########################################################################################################
@@ -431,9 +443,9 @@ def calc_qmri_stats(bids_directory, bibsnet_directory,
     mask_corr_coef = np.corrcoef(reg['warpedmovout'][mask_inds], anatomical_reference_arr[mask_inds])[0,1]
 
 
-    roi_params_metadata = {'Workflow_Description' : 'The values generated in the accompanying csv file are summary statistics from PD/T1/T2 maps that were generated from QALAS scans using the qMRI pipeline. A registration was calculated from a high resolution anatomical image to the qMRI maps, and the inverse of this registration was applied to register the segmentation image to the original maps. Summary statistics were then applied within the different regions of interest for the different maps.',
+    roi_params_metadata = {'Workflow_Description' : 'The values generated in the accompanying csv file are summary statistics from PD/T1/T2 maps that were generated using the qMRI pipeline. A registration was calculated from a high resolution anatomical image to the qMRI maps, and the inverse of this registration was applied to register the segmentation image to the original maps. Summary statistics were then applied within the different regions of interest for the different maps.',
                            'Original_Segmentation_Path' : ["bids:bibsnet:{}".format(bibsnet_seg_path.split(bibsnet_directory)[-1])],
-                           'QALAS_Registered_Segmentation_Path' : ["bids:qmri_postproc:{}".format(registered_segmentation_path.split(output_directory)[-1])],
+                           'qMRI_Registered_Segmentation_Path' : ["bids:qmri_postproc:{}".format(registered_segmentation_path.split(output_directory)[-1])],
                            'Mask_Path' : ["bids:bibsnet:{}".format(bibsnet_mask_path.split(bibsnet_directory)[-1])],
                            'Anatomical_Reference_Path' : ["bids:assembly_bids:{}".format(anatomical_reference_path.split(bids_directory)[-1])],
                            'Anatomical_Reference_Modality' : anatomical_reference_modality,
@@ -502,9 +514,9 @@ def calc_qmri_stats(bids_directory, bibsnet_directory,
             params_df = pd.DataFrame(custom_roi_params_dict)
             params_df.to_csv(output_tsv_path, index=False, sep = '\t') 
 
-            custom_roi_params_metadata = {'Workflow_Description' : 'The values generated in the accompanying csv file are summary statistics from PD/T1/T2 maps that were generated from QALAS scans using the qMRI pipeline. A registration was calculated from a high resolution anatomical image to the qMRI maps, and the inverse of this registration was applied to register the segmentation image to the original maps. Summary statistics were then applied within the different regions of interest for the different maps.',
+            custom_roi_params_metadata = {'Workflow_Description' : 'The values generated in the accompanying csv file are summary statistics from PD/T1/T2 maps that were generated using the qMRI pipeline. A registration was calculated from a high resolution anatomical image to the qMRI maps, and the inverse of this registration was applied to register the segmentation image to the original maps. Summary statistics were then applied within the different regions of interest for the different maps.',
                            'Original_Segmentation_Path' : ["bids:bibsnet:{}".format(bibsnet_seg_path.split(bibsnet_directory)[-1])],
-                           'QALAS_Registered_Segmentation_Path' : ["bids:qmri_postproc:{}".format(registered_segmentation_path.split(output_directory)[-1])],
+                           'qMRI_Registered_Segmentation_Path' : ["bids:qmri_postproc:{}".format(registered_segmentation_path.split(output_directory)[-1])],
                            'Mask_Path' : ["bids:bibsnet:{}".format(bibsnet_mask_path.split(bibsnet_directory)[-1])],
                            'Anatomical_Reference_Path' : ["bids:assembly_bids:{}".format(anatomical_reference_path.split(bids_directory)[-1])],
                            'Anatomical_Reference_Modality' : anatomical_reference_modality,
@@ -528,7 +540,7 @@ def calc_qmri_stats(bids_directory, bibsnet_directory,
     #########################################################################################################
     
     #Add json metadata for the PD/T1/T2map images that have been registered to the anatomical template
-    resampled_images_metadata = {'Workflow_Description' : 'The values generated in the accompanying images are the quantitative maps derived from QALAS scans that are then registered and resampled to a high-resolution native image for the subject (see Anatomical_Reference_Path for the image that was registered to).',
+    resampled_images_metadata = {'Workflow_Description' : 'The values generated in the accompanying images are the quantitative maps that have been registered and resampled to a high-resolution native image for the subject (see Anatomical_Reference_Path for the image that was registered to).',
                            'Segmentation_Path' : ["bids:bibsnet:{}".format(bibsnet_seg_path.split(bibsnet_directory)[-1])],
                            'Mask_Path' : ["bids:bibsnet:{}".format(bibsnet_mask_path.split(bibsnet_directory)[-1])],
                            'Anatomical_Reference_Path' : ["bids:assembly_bids:{}".format(anatomical_reference_path.split(bids_directory)[-1])],

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -211,8 +211,8 @@ def make_outline_overlay_underlay_plot_ribbon(path_to_underlay, path_to_overlay,
     return
 
 
-def calc_symri_stats(bids_directory, bibsnet_directory,
-                     symri_directory, output_directory,
+def calc_qmri_stats(bids_directory, bibsnet_directory,
+                     qmri_directory, output_directory,
                      subject_name, session_name, custom_roi_groupings = None):
     '''Function to generate items of interest based on quantitative MRI maps
     
@@ -223,7 +223,7 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         Path to the study-level BIDS directory
     bibsnet_directory : str
         Path to the study-level BIBSNET directory
-    symri_directory : str
+    qmri_directory : str
         Path to the study-level SYMRI directory
     output_directory : str
         Path to the study-level directory where output should be saved
@@ -240,7 +240,7 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     #Be sure that different directories ends in file seperator
     output_directory = os.path.join(output_directory, '')
     bibsnet_directory = os.path.join(bibsnet_directory, '')
-    symri_directory = os.path.join(symri_directory, '')
+    qmri_directory = os.path.join(qmri_directory, '')
     bids_directory = os.path.join(bids_directory, '')
     
     
@@ -282,25 +282,25 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         
         
     #Find the SyMRI Maps
-    symri_t1 = glob.glob(os.path.join(symri_directory, subject_name, 'ses*', 'anat', '*T1map.nii.gz'))
-    symri_t2 = glob.glob(os.path.join(symri_directory, subject_name, 'ses*', 'anat', '*T2map.nii.gz'))
-    symri_pd = glob.glob(os.path.join(symri_directory, subject_name, 'ses*', 'anat', '*PDmap.nii.gz')) 
-    symri_t1w_path = glob.glob(os.path.join(symri_directory, subject_name, 'ses*', 'anat', '*T1w.nii.gz'))
-    symri_t2w_path = glob.glob(os.path.join(symri_directory, subject_name, 'ses*', 'anat', '*T2w.nii.gz'))
+    qmri_t1 = glob.glob(os.path.join(qmri_directory, subject_name, 'ses*', 'anat', '*T1map.nii.gz'))
+    qmri_t2 = glob.glob(os.path.join(qmri_directory, subject_name, 'ses*', 'anat', '*T2map.nii.gz'))
+    qmri_pd = glob.glob(os.path.join(qmri_directory, subject_name, 'ses*', 'anat', '*PDmap.nii.gz')) 
+    qmri_t1w_path = glob.glob(os.path.join(qmri_directory, subject_name, 'ses*', 'anat', '*T1w.nii.gz'))
+    qmri_t2w_path = glob.glob(os.path.join(qmri_directory, subject_name, 'ses*', 'anat', '*T2w.nii.gz'))
 
-    if len(symri_t1w_path)*len(symri_t2w_path) != 1:
-        raise ValueError('Error: Expected to have exactly one T1w and T2w image, but found the following images {}.'.format(symri_t1w_path + symri_t2w_path))
+    if len(qmri_t1w_path)*len(qmri_t2w_path) != 1:
+        raise ValueError('Error: Expected to have exactly one T1w and T2w image, but found the following images {}.'.format(qmri_t1w_path + qmri_t2w_path))
 
-    if (len(symri_t1) + len(symri_t2) + len(symri_pd)) == 0:
-        raise ValueError('Error: Expected to have at least one T1map, T2map, or PDmap, but found the following images {}.'.format(symri_t1 + symri_t2 + symri_pd))
+    if (len(qmri_t1) + len(qmri_t2) + len(qmri_pd)) == 0:
+        raise ValueError('Error: Expected to have at least one T1map, T2map, or PDmap, but found the following images {}.'.format(qmri_t1 + qmri_t2 + qmri_pd))
     else:
-        symri_map_path_dict = {}
-        if len(symri_t1):
-            symri_map_path_dict['T1'] = symri_t1[0]
-        if len(symri_t2):
-            symri_map_path_dict['T2'] = symri_t2[0]
-        if len(symri_pd):
-            symri_map_path_dict['PD'] = symri_pd[0]
+        qmri_map_path_dict = {}
+        if len(qmri_t1):
+            qmri_map_path_dict['T1'] = qmri_t1[0]
+        if len(qmri_t2):
+            qmri_map_path_dict['T2'] = qmri_t2[0]
+        if len(qmri_pd):
+            qmri_map_path_dict['PD'] = qmri_pd[0]
         
     #########################################################################################################
     #########################################################################################################
@@ -313,18 +313,18 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     print('   Loading SyMRI maps')
     anatomical_reference = ants.image_read(anatomical_reference_path)
     segmentation = ants.image_read(bibsnet_seg_path)
-    symri_image_dict = {}
-    for temp_symri_map in symri_map_path_dict.keys():
-        symri_image_dict[temp_symri_map] = ants.image_read(symri_map_path_dict[temp_symri_map])
+    qmri_image_dict = {}
+    for temp_qmri_map in qmri_map_path_dict.keys():
+        qmri_image_dict[temp_qmri_map] = ants.image_read(qmri_map_path_dict[temp_qmri_map])
 
-    #Load the JSON metadata from one of original symri outputs.
+    #Load the JSON metadata from one of original qmri outputs.
     #Also remove SeriesDescription/ImageType fields that are specific to weighting.
-    map_json = next(iter(symri_map_path_dict.values())).replace('.nii.gz', '.json')
+    map_json = next(iter(qmri_map_path_dict.values())).replace('.nii.gz', '.json')
     with open(map_json, 'r') as f:
-        symri_json_dict = json.load(f)
+        qmri_json_dict = json.load(f)
     try:
-        del symri_json_dict["SeriesDescription"]
-        del symri_json_dict["ImageType"]
+        del qmri_json_dict["SeriesDescription"]
+        del qmri_json_dict["ImageType"]
     except:
         pass
 
@@ -354,32 +354,31 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     adjusted_bibsnet_mask = remove_extra_clusters_from_mask(bibsnet_mask)
     dilated_mask = ants.utils.morphology(adjusted_bibsnet_mask, 'dilate', 35)
     if anatomical_reference_modality == 'T1w':
-        symri_for_reg = ants.image_read(symri_t1w_path[0])
-        reg = ants.registration(anatomical_reference, symri_for_reg, type_of_transform='Rigid', initial_transform=None, mask=dilated_mask)
+        qmri_for_reg = ants.image_read(qmri_t1w_path[0])
+        reg = ants.registration(anatomical_reference, qmri_for_reg, type_of_transform='Rigid', initial_transform=None, mask=dilated_mask)
     elif anatomical_reference_modality == 'T2w':
-        symri_for_reg = ants.image_read(symri_t2w_path[0])
-        reg = ants.registration(anatomical_reference, symri_for_reg, type_of_transform='Rigid', initial_transform=None, mask=dilated_mask)
+        qmri_for_reg = ants.image_read(qmri_t2w_path[0])
+        reg = ants.registration(anatomical_reference, qmri_for_reg, type_of_transform='Rigid', initial_transform=None, mask=dilated_mask)
 
     #Apply the transform calculated above to the t1map, t2map, and pdmap images
     Map_Interpolation_Scheme = 'bSpline'
     maps_array_dict = {}
     registered_maps_paths = {}
     print('   Generating and saving registered SyMRI maps')
-    for temp_symri_map in symri_map_path_dict.keys():
-        temp_map = ants.image_read(symri_map_path_dict[temp_symri_map])
+    for temp_qmri_map in qmri_map_path_dict.keys():
+        temp_map = ants.image_read(qmri_map_path_dict[temp_qmri_map])
         temp_map_transformed = ants.apply_transforms(anatomical_reference, temp_map, reg['fwdtransforms'], interpolator = Map_Interpolation_Scheme)
-        maps_array_dict[temp_symri_map] = np.array(temp_map[:])
-        registered_temp_map_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.nii'.format(subject_name, session_name, anatomical_reference_modality, temp_symri_map))
-        registered_maps_paths[temp_symri_map] = registered_temp_map_path
+        maps_array_dict[temp_qmri_map] = np.array(temp_map[:])
+        registered_temp_map_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.nii'.format(subject_name, session_name, anatomical_reference_modality, temp_qmri_map))
         print('      Saving {}'.format(registered_temp_map_path))
         if os.path.exists(anat_out_dir) == False:
             os.makedirs(anat_out_dir)
         ants.image_write(temp_map_transformed, registered_temp_map_path)
         replace_file_with_gzipped_version(registered_temp_map_path)
-        registered_maps_paths[temp_symri_map] = registered_temp_map_path + '.gz'
+        registered_maps_paths[temp_qmri_map] = registered_temp_map_path + '.gz'
     #Also transform the segmentation image back to QALAS (i.e. T1map/T2map/PDmap) space
     Segmentation_Interpolation_Scheme = 'nearestNeighbor'
-    segmentation_reverse_transformed = ants.apply_transforms(symri_for_reg, segmentation, reg['fwdtransforms'], interpolator = Segmentation_Interpolation_Scheme, whichtoinvert = [True])
+    segmentation_reverse_transformed = ants.apply_transforms(qmri_for_reg, segmentation, reg['fwdtransforms'], interpolator = Segmentation_Interpolation_Scheme, whichtoinvert = [True])
     bibnset_file = bibsnet_seg_path.split('/')[-1]
     registered_segmentation_path = os.path.join(anat_out_dir, bibnset_file.replace(bibnset_file.split('_')[-3], 'space-QALAS')).replace('.gz', '')
     ants.image_write(segmentation_reverse_transformed, registered_segmentation_path)
@@ -395,10 +394,10 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     color_lut_df = load_color_lut_df()
     
     #Initialize a dictionary to store all the ROI values/names
-    measure_tpyes = ['Mean', 'Median', '1-percentile', '99-percentile', 'Std']
+    measure_types = ['Mean', 'Median', '1-percentile', '99-percentile', 'Std']
     roi_params_dict = {'Region_Name' : []}
     for temp_image_type in maps_array_dict.keys():
-        for temp_measure in measure_tpyes:
+        for temp_measure in measure_types:
             roi_params_dict[temp_image_type + '_' + temp_measure] = []
     
     #Find unique segmentation values########################################################
@@ -434,19 +433,19 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
 
     roi_params_metadata = {'Workflow_Description' : 'The values generated in the accompanying csv file are summary statistics from PD/T1/T2 maps that were generated from QALAS scans using the SyMRI pipeline. A registration was calculated from a high resolution anatomical image to the SyMRI maps, and the inverse of this registration was applied to register the segmentation image to the original maps. Summary statistics were then applied within the different regions of interest for the different maps.',
                            'Original_Segmentation_Path' : ["bids:bibsnet:{}".format(bibsnet_seg_path.split(bibsnet_directory)[-1])],
-                           'QALAS_Registered_Segmentation_Path' : ["bids:symri_postproc:{}".format(registered_segmentation_path.split(output_directory)[-1])],
+                           'QALAS_Registered_Segmentation_Path' : ["bids:qmri_postproc:{}".format(registered_segmentation_path.split(output_directory)[-1])],
                            'Mask_Path' : ["bids:bibsnet:{}".format(bibsnet_mask_path.split(bibsnet_directory)[-1])],
                            'Anatomical_Reference_Path' : ["bids:assembly_bids:{}".format(anatomical_reference_path.split(bids_directory)[-1])],
                            'Anatomical_Reference_Modality' : anatomical_reference_modality,
                            'Segmentation_Resampling_Scheme' : Segmentation_Interpolation_Scheme,
                            'Voxel_Correlation_Within_Mask' : mask_corr_coef,
-                           'Voxel_Correlation_Within_Mask_Description' : 'This is the correlation of voxel intensities between the anatomical reference image and the synthetic weighted image from symri following registration, using only voxels defined in the brain mask.'}
+                           'Voxel_Correlation_Within_Mask_Description' : 'This is the correlation of voxel intensities between the anatomical reference image and the synthetic weighted image from qmri following registration, using only voxels defined in the brain mask.'}
     
     roi_params_metadata['Original_SyMRI_Images'] = []
-    for temp_symri_map in symri_map_path_dict.keys():
-        roi_params_metadata['Original_SyMRI_Images'].append("bids:symri:{}".format(symri_map_path_dict[temp_symri_map].split(symri_directory)[-1]))
+    for temp_qmri_map in qmri_map_path_dict.keys():
+        roi_params_metadata['Original_SyMRI_Images'].append("bids:qmri:{}".format(qmri_map_path_dict[temp_qmri_map].split(qmri_directory)[-1]))
     roi_params_metadata.update(grab_anatomical_reference_metadata(anatomical_reference_path))
-    roi_params_metadata['Original_SyMRI_JSON_Metadata'] = symri_json_dict
+    roi_params_metadata['Original_SyMRI_JSON_Metadata'] = qmri_json_dict
 
     roi_params_metadata_json = json.dumps(roi_params_metadata, indent = 5)
     output_json_path = os.path.join(anat_out_dir, '{}_{}_desc-ParametricROIValues.json'.format(subject_name, session_name))
@@ -462,7 +461,7 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
             print('   Calculating Custom ROI Relaxometry Values for {}'.format(temp_grouping_path))
             custom_roi_params_dict = {'Region_Name' : []}
             for temp_image_type in maps_array_dict.keys():
-                for temp_measure in measure_tpyes:
+                for temp_measure in measure_types:
                     custom_roi_params_dict[temp_image_type + '_' + temp_measure] = []
 
 
@@ -505,19 +504,19 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
 
             custom_roi_params_metadata = {'Workflow_Description' : 'The values generated in the accompanying csv file are summary statistics from PD/T1/T2 maps that were generated from QALAS scans using the SyMRI pipeline. A registration was calculated from a high resolution anatomical image to the SyMRI maps, and the inverse of this registration was applied to register the segmentation image to the original maps. Summary statistics were then applied within the different regions of interest for the different maps.',
                            'Original_Segmentation_Path' : ["bids:bibsnet:{}".format(bibsnet_seg_path.split(bibsnet_directory)[-1])],
-                           'QALAS_Registered_Segmentation_Path' : ["bids:symri_postproc:{}".format(registered_segmentation_path.split(output_directory)[-1])],
+                           'QALAS_Registered_Segmentation_Path' : ["bids:qmri_postproc:{}".format(registered_segmentation_path.split(output_directory)[-1])],
                            'Mask_Path' : ["bids:bibsnet:{}".format(bibsnet_mask_path.split(bibsnet_directory)[-1])],
                            'Anatomical_Reference_Path' : ["bids:assembly_bids:{}".format(anatomical_reference_path.split(bids_directory)[-1])],
                            'Anatomical_Reference_Modality' : anatomical_reference_modality,
                            'Segmentation_Resampling_Scheme' : Segmentation_Interpolation_Scheme,
                            'Voxel_Correlation_Within_Mask' : mask_corr_coef,
-                           'Voxel_Correlation_Within_Mask_Description' : 'This is the correlation of voxel intensities between the anatomical reference image and the synthetic weighted image from symri following registration, using only voxels defined in the brain mask.'}
+                           'Voxel_Correlation_Within_Mask_Description' : 'This is the correlation of voxel intensities between the anatomical reference image and the synthetic weighted image from qmri following registration, using only voxels defined in the brain mask.'}
             custom_roi_params_metadata.update(grab_anatomical_reference_metadata(anatomical_reference_path))
-            custom_roi_params_metadata['Original_SyMRI_JSON_Metadata'] = symri_json_dict
+            custom_roi_params_metadata['Original_SyMRI_JSON_Metadata'] = qmri_json_dict
             custom_roi_params_metadata['Custom_ROI_Grouping'] = temp_groupings
             roi_params_metadata['Original_SyMRI_Images'] = []
-            for temp_symri_map in symri_map_path_dict.keys():
-                roi_params_metadata['Original_SyMRI_Images'].append("bids:symri:{}".format(symri_map_path_dict[temp_symri_map].split(symri_directory)[-1]))
+            for temp_qmri_map in qmri_map_path_dict.keys():
+                roi_params_metadata['Original_SyMRI_Images'].append("bids:qmri:{}".format(qmri_map_path_dict[temp_qmri_map].split(qmri_directory)[-1]))
             custom_roi_params_metadata_json = json.dumps(custom_roi_params_metadata, indent = 5)
             output_json_path = os.path.join(anat_out_dir, '{}_{}_desc-{}.json'.format(subject_name, session_name, temp_grouping_partial_name))
 
@@ -536,13 +535,13 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
                            'Anatomical_Reference_Modality' : anatomical_reference_modality,
                            'Resampling_Scheme' : Map_Interpolation_Scheme}
     roi_params_metadata['Original_SyMRI_Images'] = []
-    for temp_symri_map in symri_map_path_dict.keys():
-        roi_params_metadata['Original_SyMRI_Images'].append("bids:symri:{}".format(symri_map_path_dict[temp_symri_map].split(symri_directory)[-1]))
+    for temp_qmri_map in qmri_map_path_dict.keys():
+        roi_params_metadata['Original_SyMRI_Images'].append("bids:qmri:{}".format(qmri_map_path_dict[temp_qmri_map].split(qmri_directory)[-1]))
     resampled_images_metadata.update(grab_anatomical_reference_metadata(anatomical_reference_path))
-    resampled_images_metadata['Original_SyMRI_JSON_Metadata'] = symri_json_dict
+    resampled_images_metadata['Original_SyMRI_JSON_Metadata'] = qmri_json_dict
     resampled_images_metadata_json = json.dumps(resampled_images_metadata, indent = 5)
-    for temp_symri_map in symri_map_path_dict.keys():
-        output_json_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.json'.format(subject_name, session_name, anatomical_reference_modality, temp_symri_map))
+    for temp_qmri_map in qmri_map_path_dict.keys():
+        output_json_path = os.path.join(anat_out_dir, '{}_{}_space-{}_desc-QALAS_{}map.json'.format(subject_name, session_name, anatomical_reference_modality, temp_qmri_map))
         with open(output_json_path, 'w') as f:
             f.write(resampled_images_metadata_json) 
     
@@ -559,5 +558,11 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
     
     make_outline_overlay_underlay_plot_ribbon(registered_path_for_underlay, bibsnet_seg_path, ap_buffer_size = 3, crop_buffer=20, num_total_images=9, dpi=400,
                                     underlay_cmap='Greys', linewidths=.1, output_path=alignment_figure_output, close_plot=True)
+    with open(alignment_figure_output.replace('.png', '.json'), 'w') as f:
+        alignment_figure_metadata = {'Workflow_Description' : 'The image generated in the accompanying figure is a visual representation of the registration quality of the segmentation image to the high resolution anatomical image. The underlay is a quantitative image that has been registered to the anatomical image, and the overlay is the segmentation image that has been registered to the T2map image. The figure is intended to be used as a quality control aid to assess the registration quality of the segmentation image to the anatomical image.',
+                                     'Segmentation_Path' : ["bids:bibsnet:{}".format(bibsnet_seg_path.split(bibsnet_directory)[-1])],
+                                     'Underlay_Path' : ["bids:qmri_postproc:{}".format(registered_path_for_underlay.split(output_directory)[-1])],
+                                     }
+        json.dump(alignment_figure_metadata, f, indent = 5)
 
     return

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -296,7 +296,7 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
         raise ValueError('Error: Expected to have exactly one T1w and T2w image, but found the following images {}.'.format(symri_t1w_path + symri_t2w_path))
 
     if (len(symri_t1) + len(symri_t2) + len(symri_pd)) == 0:
-        raise ValueError('Error: Expected to have exactly at least one T1map, T2map, or PDmap, but found the following images {}.'.format(symri_t1 + symri_t2 + symri_pd))
+        raise ValueError('Error: Expected to have at least one T1map, T2map, or PDmap, but found the following images {}.'.format(symri_t1 + symri_t2 + symri_pd))
     else:
         symri_map_path_dict = {}
         if len(symri_t1):
@@ -323,7 +323,7 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
 
     #Load the JSON metadata from one of original symri outputs.
     #Also remove SeriesDescription/ImageType fields that are specific to weighting.
-    map_json = next(iter(symri_map_path_dict)).replace('.nii.gz', '.json')
+    map_json = next(iter(symri_map_path_dict.values())).replace('.nii.gz', '.json')
     with open(map_json, 'r') as f:
         symri_json_dict = json.load(f)
     try:

--- a/postproc_code/qmri_postproc.py
+++ b/postproc_code/qmri_postproc.py
@@ -426,9 +426,9 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
 
     if os.path.exists(anat_out_dir) == False:
         os.makedirs(anat_out_dir)
-    output_csv_path = os.path.join(anat_out_dir, '{}_{}_desc-ParametricROIValues.csv'.format(subject_name, session_name))
+    output_tsv_path = os.path.join(anat_out_dir, '{}_{}_desc-ParametricROIValues.tsv'.format(subject_name, session_name))
     params_df = pd.DataFrame(roi_params_dict)
-    params_df.to_csv(output_csv_path, index=False) 
+    params_df.to_csv(output_tsv_path, index=False, sep = '\t') 
 
     mask_inds = mask_arr > 0.5
     mask_corr_coef = np.corrcoef(reg['warpedmovout'][mask_inds], anatomical_reference_arr[mask_inds])[0,1]
@@ -501,9 +501,9 @@ def calc_symri_stats(bids_directory, bibsnet_directory,
                             raise ValueError('   Error: Unknown error when calculating custom summary statistics for {}.'.format(temp_grouping))
 
             temp_grouping_partial_name = temp_grouping_path.split('/')[-1].replace('.json', '')
-            output_csv_path = os.path.join(anat_out_dir, '{}_{}_desc-{}.csv'.format(subject_name, session_name, temp_grouping_partial_name))
+            output_tsv_path = os.path.join(anat_out_dir, '{}_{}_desc-{}.tsv'.format(subject_name, session_name, temp_grouping_partial_name))
             params_df = pd.DataFrame(custom_roi_params_dict)
-            params_df.to_csv(output_csv_path, index=False) 
+            params_df.to_csv(output_tsv_path, index=False, sep = '\t') 
 
             custom_roi_params_metadata = {'Workflow_Description' : 'The values generated in the accompanying csv file are summary statistics from PD/T1/T2 maps that were generated from QALAS scans using the SyMRI pipeline. A registration was calculated from a high resolution anatomical image to the SyMRI maps, and the inverse of this registration was applied to register the segmentation image to the original maps. Summary statistics were then applied within the different regions of interest for the different maps.',
                            'Original_Segmentation_Path' : ["bids:bibsnet:{}".format(bibsnet_seg_path.split(bibsnet_directory)[-1])],

--- a/postproc_code/run.py
+++ b/postproc_code/run.py
@@ -104,7 +104,8 @@ def main():
             qmri_postproc.calc_qmri_stats(bids_dir, bibsnet_deriv_dir,
                                         qmri_deriv_dir, output_dir,
                                         temp_participant, temp_session,
-                                        custom_roi_groupings = region_groupings_json)
+                                        custom_roi_groupings = region_groupings_json,
+                                        sequence_name_source = args.sequence_name_source)
             print('Finished with: {}, {}'.format(temp_participant, temp_session))
 
 if __name__ == "__main__":

--- a/postproc_code/run.py
+++ b/postproc_code/run.py
@@ -96,7 +96,7 @@ def main():
                 continue
             print('Starting processing for: {}, {}'.format(temp_participant, temp_session))
             if os.path.exists(os.path.join(qmri_deriv_dir, temp_participant, temp_session)) == False:
-                print('   No SyMRI Relaxometry Maps directory found for the following, skipping processing: {}, {}'.format(temp_participant, temp_session))
+                print('   No qMRI Relaxometry Maps directory found for the following, skipping processing: {}, {}'.format(temp_participant, temp_session))
                 continue
             if os.path.exists(os.path.join(bibsnet_deriv_dir, temp_participant, temp_session)) == False:
                 print('   No BIBSNET/CABINET segmentations directory found for the following, skipping processing: {}, {}'.format(temp_participant, temp_session))

--- a/postproc_code/run.py
+++ b/postproc_code/run.py
@@ -25,9 +25,9 @@ def main():
     analysis_level = args.analysis_level
     if analysis_level != 'participant':
         raise ValueError('Error: analysis level must be participant, but program received: ' + analysis_level)
-    symri_deriv_dir = args.symri_deriv_dir
-    if os.path.isabs(symri_deriv_dir) == False:
-        symri_deriv_dir = os.path.join(cwd, symri_deriv_dir)
+    qmri_deriv_dir = args.qmri_deriv_dir
+    if os.path.isabs(qmri_deriv_dir) == False:
+        qmri_deriv_dir = os.path.join(cwd, qmri_deriv_dir)
     bibsnet_deriv_dir = args.bibsnet_deriv_dir
     if os.path.isabs(bibsnet_deriv_dir) == False:
         bibsnet_deriv_dir = os.path.join(cwd, bibsnet_deriv_dir)
@@ -95,14 +95,14 @@ def main():
                 print('Session folder already exists at the following path. Either delete folder, run with --overwrite_existing flag to reprocess, or with --skip_existing to ignore existing folders: ' + session_path)
                 continue
             print('Starting processing for: {}, {}'.format(temp_participant, temp_session))
-            if os.path.exists(os.path.join(symri_deriv_dir, temp_participant, temp_session)) == False:
+            if os.path.exists(os.path.join(qmri_deriv_dir, temp_participant, temp_session)) == False:
                 print('   No SyMRI Relaxometry Maps directory found for the following, skipping processing: {}, {}'.format(temp_participant, temp_session))
                 continue
             if os.path.exists(os.path.join(bibsnet_deriv_dir, temp_participant, temp_session)) == False:
                 print('   No BIBSNET/CABINET segmentations directory found for the following, skipping processing: {}, {}'.format(temp_participant, temp_session))
                 continue
-            qmri_postproc.calc_symri_stats(bids_dir, bibsnet_deriv_dir,
-                                        symri_deriv_dir, output_dir,
+            qmri_postproc.calc_qmri_stats(bids_dir, bibsnet_deriv_dir,
+                                        qmri_deriv_dir, output_dir,
                                         temp_participant, temp_session,
                                         custom_roi_groupings = region_groupings_json)
             print('Finished with: {}, {}'.format(temp_participant, temp_session))


### PR DESCRIPTION
Allows support for (1) when the qmri pipeline only generates one or two of the quantitative images (i.e. T1map, T2map, PDmap), and (2) shifts the responsibility of generating synthetic weighted images to the original pipeline